### PR TITLE
Добавил README.md к публикуемым файлам

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     package_data={
         '': [
             '../LICENSE',
+            '../README.md',
         ],
     },
 )


### PR DESCRIPTION
В **setup.py** используется README.md, хотя в package_data он не указан
Из-за этого происходит следующая ошибка:
```
setup.py test # в другом пакете, где пытаюсь использовать dohq_youtrack в install_requires
Searching for dohq_youtrack
Reading https://pypi.python.org/simple/dohq_youtrack/
Downloading https://pypi.python.org/packages/16/d4/941c53e2ce25e5a23e080137a20d327cfd95220bfc76449dd7179f7dc8f5/dohq-youtrack-0.0.1.dev18.tar.gz#md5=01f173633a31aac47a80d01bcdf3304e
Best match: dohq-youtrack 0.0.1.dev18
Processing dohq-youtrack-0.0.1.dev18.tar.gz
Writing C:\Users\aburov\AppData\Local\Temp\easy_install-p7i9telw\dohq-youtrack-0.0.1.dev18\setup.cfg
Running dohq-youtrack-0.0.1.dev18\setup.py -q bdist_egg --dist-dir C:\Users\aburov\AppData\Local\Temp\easy_install-p7i9telw\dohq-youtrack-0.0.1.dev18\egg-dist-tmp-o95yjbes
error: [Errno 2] No such file or directory: 'README.md'
```