### PR TITLE
get_issues for all projects at once

### DIFF
--- a/youtrack/connection.py
+++ b/youtrack/connection.py
@@ -731,7 +731,10 @@ class Connection(object):
             params['updatedAfter'] = updated_after
         if wikify is not None:
             params['wikifyDescription'] = wikify
-        response, content = self._req('GET', '/issue/byproject/' + urlquote(project_id) + "?" +
+        path = '/issue'
+        if project_id:
+        path += '/byproject/' + urlquote(project_id)
+        response, content = self._req('GET', path + "?" +
                                       urllib.parse.urlencode(params))
         xml = minidom.parseString(content)
         return [youtrack.Issue(e, self) for e in xml.documentElement.childNodes if e.nodeType == Node.ELEMENT_NODE]

--- a/youtrack/connection.py
+++ b/youtrack/connection.py
@@ -733,9 +733,9 @@ class Connection(object):
             params['wikifyDescription'] = wikify
         path = '/issue'
         if project_id:
-        path += '/byproject/' + urlquote(project_id)
-        response, content = self._req('GET', path + "?" +
-                                      urllib.parse.urlencode(params))
+            path += '/byproject/' + urlquote(project_id)
+        content = self._req('GET', path + "?" +
+                                      urllib.parse.urlencode(params))[1]
         xml = minidom.parseString(content)
         return [youtrack.Issue(e, self) for e in xml.documentElement.childNodes if e.nodeType == Node.ELEMENT_NODE]
 


### PR DESCRIPTION
There is a feature that works in official **pyyoutrack**: in case of passing `''` to `project_id` request is build in way to select issues for *all projects*. It is very useful feature and I need it.
It would be great for me if you add this code to master.